### PR TITLE
extend to non prime power modulus

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ pub fn find_cyclic_subgroup(modulus: i64, n: i64) -> (i64, i64) {
 
             //Lift using CRT
             result_element = crt(result_element, p.pow(e), element_in_factor, modulus/p.pow(e));
-            return (result_element, n)
+            result_order = n
         }
     }
 
@@ -217,25 +217,18 @@ pub fn find_cyclic_subgroup(modulus: i64, n: i64) -> (i64, i64) {
     (result_element, result_order)
 }
 
-fn crt(a1: i64, n1: i64, a2: i64, n2: i64) -> i64 {
-    // Solve x = a1 mod n1 and x = a2 mod n2
-    let n = n1 * n2;
-
-    // Find the modular inverses
-    let (inv1, _) = extended_gcd(n1, n2); // inv1 is the inverse of n2 mod n1
-    let (inv2, _) = extended_gcd(n2, n1); // inv2 is the inverse of n1 mod n2
-
-    // CRT formula: x = (a1 * n2 * inv(n2, n1) + a2 * n1 * inv(n1, n2)) mod n
-    let x = (a1 * n2 * inv1 + a2 * n1 * inv2) % n;
-
-    // Ensure non-negative result
-    if x < 0 {
+fn crt(a1: i64, n1: i64, a2: i64, n2: i64) -> i64{
+    //Solve x = a1 mod n1 and x = a2 mod n2
+    let n = n1*n2;
+    let (inv1, _) = extended_gcd(n1, n2);
+    let (inv2, _) = extended_gcd(n2, n1);
+    let x = (a1*inv2%n*n2%n + a2*inv1%n*n1%n)%n;
+    if x < 0{
         x + n
-    } else {
+    }else{
         x
     }
 }
-
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,13 @@ fn gcd(mut a: i64, mut b: i64) -> i64 {
     a.abs()
 }
 
+pub fn is_prime_power(n: i64) -> bool {
+    if n <= 1 {
+        return false; // 1 and numbers <= 1 are not prime powers
+    }
+    factorize(n).len() == 1
+}
+
 // Modular arithmetic functions using i64
 fn mod_add(a: i64, b: i64, p: i64) -> i64 {
     (a + b) % p
@@ -40,10 +47,18 @@ fn mod_inv(a: i64, p: i64) -> i64 {
 }
 
 // Compute n-th root of unity (omega) for p not necessarily prime
-pub fn omega(root: i64, p: i64, n: usize) -> i64 {
-    let grp_size = totient(p as u64) as i64;
-    assert!(grp_size % n as i64 == 0, "{} does not divide {}", n, grp_size);
-    mod_exp(root, grp_size / n as i64, p) // order of mult. group is Euler's totient function
+pub fn omega(modulus: i64, n: usize) -> i64 {
+    let factors = factorize(modulus as i64);
+    if factors.len() == 1 {
+        let (p, e) = factors.into_iter().next().unwrap();
+        let root = primitive_root(p, e); // primitive root mod p
+        let grp_size = totient(modulus as u64) as i64;
+        assert!(grp_size % n as i64 == 0, "{} does not divide {}", n, grp_size);
+        return mod_exp(root, grp_size / n as i64, modulus) // order of mult. group is Euler's totient function
+    }
+    else {
+        return cyclic_subgroup_gen(modulus, n as i64)
+    }
 }
 
 // Forward transform using NTT, output bit-reversed 
@@ -174,7 +189,7 @@ fn find_primitive_root_mod_p(p: i64) -> i64 {
     0 // Should never happen
 }
 
-pub fn find_cyclic_subgroup(modulus: i64, n: i64) -> i64 {
+pub fn cyclic_subgroup_gen(modulus: i64, n: i64) -> i64 {
     let factors = factorize(modulus); // factor the modulus
     for (&p, &e) in &factors {
         let phi = (p - 1) * p.pow(e - 1); // Euler's totient function

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,16 +11,6 @@ fn gcd(mut a: i64, mut b: i64) -> i64 {
     a.abs()
 }
 
-fn extended_gcd(a: i64, b: i64) -> (i64, i64) {
-    if b == 0 {
-        return (1, 0);
-    }
-    let (x1, y1) = extended_gcd(b, a % b);
-    let x = y1;
-    let y = x1 - y1 * (a / b);
-    (x, y)
-}
-
 /// Compute LCM of two numbers.
 fn lcm(a: i64, b: i64) -> i64 {
     (a * b) / gcd(a, b)
@@ -201,6 +191,7 @@ pub fn find_cyclic_subgroup(modulus: i64, n: i64) -> (i64, i64) {
     for (&p, &e) in &factors {
         let phi = (p - 1) * p.pow(e - 1);
         if phi % n == 0 {
+            println!("phi: {}", phi);
             let g = primitive_root(p, e);
             let order = phi / n; // Find an element of order n (or a multiple of n)
             let element_in_factor = mod_exp(g, order, p.pow(e));
@@ -217,17 +208,12 @@ pub fn find_cyclic_subgroup(modulus: i64, n: i64) -> (i64, i64) {
     (result_element, result_order)
 }
 
-fn crt(a1: i64, n1: i64, a2: i64, n2: i64) -> i64{
-    //Solve x = a1 mod n1 and x = a2 mod n2
-    let n = n1*n2;
-    let (inv1, _) = extended_gcd(n1, n2);
-    let (inv2, _) = extended_gcd(n2, n1);
-    let x = (a1*inv2%n*n2%n + a2*inv1%n*n1%n)%n;
-    if x < 0{
-        x + n
-    }else{
-        x
-    }
+pub fn crt(a1: i64, n1: i64, a2: i64, n2: i64) -> i64 {
+    let n = n1 * n2;
+    let m1 = mod_inv(n1, n2); // Inverse of n1 mod n2
+    let m2 = mod_inv(n2, n1); // Inverse of n2 mod n1
+    let x = (a1 * m2 * n2 + a2 * m1 * n1) % n;
+    if x < 0 { x + n } else { x }
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub fn omega(modulus: i64, n: usize) -> i64 {
         return mod_exp(root, grp_size / n as i64, modulus) // order of mult. group is Euler's totient function
     }
     else {
-        return root(modulus, n as i64)
+        return root_of_unity(modulus, n as i64)
     }
 }
 
@@ -156,9 +156,8 @@ fn factorize(n: i64) -> HashMap<i64, u32> {
 
 /// Fast computation of a primitive root mod p^e
 pub fn primitive_root(p: i64, e: u32) -> i64 {
-
-    // Find a primitive root mod p
-    let g = find_primitive_root_mod_p(p);
+    
+    let g = primitive_root_mod_p(p);
 
     // Lift it to p^e
     let mut g_lifted = g;
@@ -171,10 +170,9 @@ pub fn primitive_root(p: i64, e: u32) -> i64 {
 }
 
 /// Finds a primitive root modulo a prime p
-fn find_primitive_root_mod_p(p: i64) -> i64 {
+fn primitive_root_mod_p(p: i64) -> i64 {
     let phi = p - 1;
     let factors = factorize(phi); // Reusing factorize to get both prime factors and multiplicities
-
     for g in 2..p {
         // Check if g is a primitive root by checking mod_exp conditions with all prime factors of phi
         if factors.iter().all(|(&q, _)| mod_exp(g, phi / q, p) != 1) {
@@ -185,7 +183,7 @@ fn find_primitive_root_mod_p(p: i64) -> i64 {
 }
 
 // Compute the n-th root of unity modulo a composite modulus
-pub fn root(modulus: i64, n: i64) -> i64 {
+pub fn root_of_unity(modulus: i64, n: i64) -> i64 {
     let factors = factorize(modulus); // factor the modulus
     for (&p, &e) in &factors {
         let phi = (p - 1) * p.pow(e - 1); // Euler's totient function
@@ -197,6 +195,20 @@ pub fn root(modulus: i64, n: i64) -> i64 {
         }
     }
     panic!("could not find element of order n");
+}
+
+pub fn verify_root_of_unity(omega: i64, n: i64, modulus: i64) -> bool {
+    assert!(mod_exp(omega, n, modulus as i64) == 1, "omega is not an n-th root of unity");
+    for k in 1..n {
+        let mut sum = 0i64;
+        for j in 0..n {
+            sum = (sum + mod_exp(omega, j * k, modulus)) % modulus;
+        }
+        if sum != 0 {
+            return false;
+        }
+    }
+    true
 }
 
 pub fn crt(a1: i64, n1: i64, a2: i64, n2: i64) -> i64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,6 @@ fn gcd(mut a: i64, mut b: i64) -> i64 {
     a.abs()
 }
 
-/// Compute LCM of two numbers.
-fn lcm(a: i64, b: i64) -> i64 {
-    (a * b) / gcd(a, b)
-}
-
 // Modular arithmetic functions using i64
 fn mod_add(a: i64, b: i64, p: i64) -> i64 {
     (a + b) % p
@@ -179,33 +174,18 @@ fn find_primitive_root_mod_p(p: i64) -> i64 {
     0 // Should never happen
 }
 
-pub fn find_cyclic_subgroup(modulus: i64, n: i64) -> (i64, i64) {
-    if n == 0 || (n & (n - 1)) != 0 {
-        panic!("n must be a power of 2");
-    }
-
-    let factors = factorize(modulus);
-    let mut result_element = 1; // Initialize to 1 for CRT
-    let mut result_order = 1;
-
+pub fn find_cyclic_subgroup(modulus: i64, n: i64) -> i64 {
+    let factors = factorize(modulus); // factor the modulus
     for (&p, &e) in &factors {
-        let phi = (p - 1) * p.pow(e - 1);
+        let phi = (p - 1) * p.pow(e - 1); // Euler's totient function
         if phi % n == 0 {
-            println!("phi: {}", phi);
-            let g = primitive_root(p, e);
-            let order = phi / n; // Find an element of order n (or a multiple of n)
-            let element_in_factor = mod_exp(g, order, p.pow(e));
-
-            //Lift using CRT
-            result_element = crt(result_element, p.pow(e), element_in_factor, modulus/p.pow(e));
-            result_order = n
+            let g = primitive_root(p, e); // find a primitive root mod p^e
+            let exp = phi / n; // exponent of the primitive root
+            let order_n_elem = mod_exp(g, exp, p.pow(e)); // element of mult. order n mod p^e
+            return crt(1, modulus/p.pow(e), order_n_elem, p.pow(e)); // lift using CRT
         }
     }
-
-    if result_order == 1{
-        panic!("could not find element of order n");
-    }
-    (result_element, result_order)
+    panic!("could not find element of order n");
 }
 
 pub fn crt(a1: i64, n1: i64, a2: i64, n2: i64) -> i64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,24 +234,13 @@ pub fn root_of_unity(modulus: i64, n: i64) -> i64 {
     let factors = factorize(modulus);
     let mut result = 1;
 
-    // Compute the divisors d_i such that lcm(d_i for all i) = n
-    let phi: Vec<i64> = factors.iter().map(|(&p, &e)| (p - 1) * p.pow(e - 1)).collect();
-    let divisors = divisors_with_given_lcm(&phi, n).expect("Could not find divisors with LCM equal to n");
-
-    for (i, (&p, &e)) in factors.iter().enumerate() {
-        let d = divisors[i];  // Use the divisor for the current factor
-        if d > 1 {
-            let g = primitive_root(p, e);  // Find primitive root mod p^e
-            let phi = (p - 1) * p.pow(e - 1); // Euler's totient function
-            let exp = phi / d; // Compute exponent for order d
-            let order_d_elem = mod_exp(g, exp, p.pow(e)); // Element of order d
-
-            // Combine with the running result using CRT
-            result = crt(result, modulus / p.pow(e), order_d_elem, p.pow(e));
-        }
-    }
-
-    result
+    for (&p, &e) in factors.iter() {
+		// Find primitive nth root of unity mod p^e
+		let omega = omega(p.pow(e), n.try_into().unwrap());
+		// Combine with the running result using CRT
+        result = crt(result, modulus / p.pow(e), omega, p.pow(e));
+	}
+	result
 }
 
 pub fn verify_root_of_unity(omega: i64, n: i64, modulus: i64) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub fn omega(modulus: i64, n: usize) -> i64 {
         return mod_exp(root, grp_size / n as i64, modulus) // order of mult. group is Euler's totient function
     }
     else {
-        return cyclic_subgroup_gen(modulus, n as i64)
+        return root(modulus, n as i64)
     }
 }
 
@@ -184,7 +184,8 @@ fn find_primitive_root_mod_p(p: i64) -> i64 {
     0 // Should never happen
 }
 
-pub fn cyclic_subgroup_gen(modulus: i64, n: i64) -> i64 {
+// Compute the n-th root of unity modulo a composite modulus
+pub fn root(modulus: i64, n: i64) -> i64 {
     let factors = factorize(modulus); // factor the modulus
     for (&p, &e) in &factors {
         let phi = (p - 1) * p.pow(e - 1); // Euler's totient function

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,11 +156,8 @@ fn factorize(n: i64) -> HashMap<i64, u32> {
 
 /// Fast computation of a primitive root mod p^e
 pub fn primitive_root(p: i64, e: u32) -> i64 {
-    
     let g = primitive_root_mod_p(p);
-
-    // Lift it to p^e
-    let mut g_lifted = g;
+    let mut g_lifted = g; // Lift it to p^e
     for _ in 1..e {
         if g_lifted.pow((p - 1) as u32) % p.pow(e) == 1 {
             g_lifted += p.pow(e - 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub fn omega(modulus: i64, n: usize) -> i64 {
         let (p, e) = factors.into_iter().next().unwrap();
         let root = primitive_root(p, e); // primitive root mod p
         let grp_size = totient(modulus as u64) as i64;
-        assert!(grp_size % 2*n as i64 == 0, "{} does not divide {}", 2*n, grp_size);
+        assert!(grp_size % n as i64 == 0, "{} does not divide {}", n, grp_size);
         return mod_exp(root, grp_size / n as i64, modulus) // order of mult. group is Euler's totient function
     }
     else {
@@ -198,13 +198,10 @@ pub fn crt(a1: i64, n1: i64, a2: i64, n2: i64) -> i64 {
 pub fn root_of_unity(modulus: i64, n: i64) -> i64 {
     let factors = factorize(modulus);
     let mut result = 1;
-    let mut omega_is_square = false;
     for (&p, &e) in factors.iter() {
 		let omega = omega(p.pow(e), n.try_into().unwrap()); // Find primitive nth root of unity mod p^e
         result = crt(result, modulus / p.pow(e), omega, p.pow(e)); // Combine with the running result using CRT
-        omega_is_square = omega_is_square || totient(p.pow(e) as u64) % (2*n as u64) == 0;
 	}
-    assert!(omega_is_square, "no 2n-th root of unity exists modulo {}", modulus);
 	result
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,14 +24,6 @@ pub fn mod_exp(mut base: i64, mut exp: i64, p: i64) -> i64 {
     result
 }
 
-fn gcd(a: i64, b: i64) -> i64 {
-    if b == 0 {
-        a.abs()
-    } else {
-        gcd(b, a % b)
-    }
-}
-
 fn extended_gcd(a: i64, b: i64) -> (i64, i64, i64) {
     if b == 0 {
         (a, 1, 0)  // gcd, x, y

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,22 +2,6 @@ use reikna::totient::totient;
 use reikna::factor::quick_factorize;
 use std::collections::HashMap;
 
-fn gcd(mut a: i64, mut b: i64) -> i64 {
-    while b != 0 {
-        let temp = b;
-        b = a % b;
-        a = temp;
-    }
-    a.abs()
-}
-
-pub fn is_prime_power(n: i64) -> bool {
-    if n <= 1 {
-        return false; // 1 and numbers <= 1 are not prime powers
-    }
-    factorize(n).len() == 1
-}
-
 // Modular arithmetic functions using i64
 fn mod_add(a: i64, b: i64, p: i64) -> i64 {
     (a + b) % p
@@ -40,10 +24,21 @@ pub fn mod_exp(mut base: i64, mut exp: i64, p: i64) -> i64 {
     result
 }
 
-//compute the modular inverse of a modulo p using Fermat's little theorem, p not necessarily prime
-fn mod_inv(a: i64, p: i64) -> i64 {
-    assert!(gcd(a, p) == 1, "{} and {} are not coprime", a, p);
-    mod_exp(a, totient(p as u64) as i64 - 1, p) // order of mult. group is Euler's totient function
+fn extended_gcd(a: i64, b: i64) -> (i64, i64, i64) {
+    if b == 0 {
+        (a, 1, 0)  // gcd, x, y
+    } else {
+        let (gcd, x1, y1) = extended_gcd(b, a % b);
+        (gcd, y1, x1 - (a / b) * y1)
+    }
+}
+
+pub fn mod_inv(a: i64, modulus: i64) -> i64 {
+    let (gcd, x, _) = extended_gcd(a, modulus);
+    if gcd != 1 {
+        panic!("{} and {} are not coprime, no inverse exists", a, modulus);
+    }
+    (x % modulus + modulus) % modulus  // Ensure a positive result
 }
 
 // Compute n-th root of unity (omega) for p not necessarily prime

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,15 +208,7 @@ pub fn root_of_unity(modulus: i64, n: i64) -> i64 {
 //ensure the root of unity satisfies sum_{j=0}^{n-1} omega^{jk} = 0 for 1 \le k < n
 pub fn verify_root_of_unity(omega: i64, n: i64, modulus: i64) -> bool {
     assert!(mod_exp(omega, n, modulus as i64) == 1, "omega is not an n-th root of unity");
-    for k in 1..n {
-        let mut sum = 0i64;
-        for j in 0..n {
-            sum = (sum + mod_exp(omega, j * k, modulus)) % modulus;
-        }
-        if sum != 0 {
-            return false;
-        }
-    }
+    assert!(mod_exp(omega, n/2, modulus as i64) == modulus-1, "omgea^(n/2) != -1 (mod modulus)");
     true
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,16 +181,19 @@ fn find_primitive_root_mod_p(p: i64) -> i64 {
 
 /// Finds an element in (Z/NZ)* whose order is divisible by `n`.
 pub fn find_cyclic_subgroup(modulus: i64, n: i64) -> (i64, i64) {
+    // Check if n is a power of 2
     if n == 0 || (n & (n - 1)) != 0 {
         panic!("n must be a power of 2");
     }
 
+    // Factorize modulus (assuming a function exists)
     let factors = factorize(modulus);
     let mut generators = Vec::new();
     let mut orders = Vec::new();
 
+    // Loop through factors to find generators and orders
     for (&p, &e) in &factors {
-        let phi = (p - 1) * p.pow(e - 1);
+        let phi = (p - 1) * p.pow(e - 1); // Euler's totient function
         let g = primitive_root(p, e);
         generators.push(g);
         orders.push(phi);
@@ -199,12 +202,17 @@ pub fn find_cyclic_subgroup(modulus: i64, n: i64) -> (i64, i64) {
     let mut chosen_element = 1;
     let mut chosen_order = 1;
 
+    // Loop through generators and orders to find element with required order
     for (&g, &k) in generators.iter().zip(orders.iter()) {
-        let required_order = lcm(k, n); // Ensure the subgroup order is divisible by n
-        let exponent = required_order / gcd(k, required_order); // Pick the exponent carefully
-        chosen_element = (chosen_element * mod_exp(g, exponent, modulus)) % modulus;
-        chosen_order = lcm(chosen_order, required_order);
+        // Calculate required order
+        let required_order = lcm(k, n); // Least common multiple
+        let exponent = required_order / gcd(k, required_order); // Adjust exponent
+        chosen_element = (chosen_element * mod_exp(g, exponent, modulus)) % modulus; // mod_exp computes power mod modulus
+        chosen_order = lcm(chosen_order, k / gcd(k, n)); // Adjust chosen order
     }
+
+    // Assert the order is divisible by n
+    assert_eq!(chosen_order % n, 0);
 
     (chosen_element, chosen_order)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ fn main() {
     let c_fast = polymul_ntt(&a, &b, n, p, omega);
 
     // Output the results
+    println!("verify omega = {}", verify_root_of_unity(omega, n as i64, p));
     println!("Polynomial A: {:?}", a);
     println!("Polynomial B: {:?}", b);
     println!("Transformed A: {:?}", a_ntt);

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
     println!("Polynomial multiplication method using NTT: {:?}", c_fast);
 
     let modulus = 45; // Example modulus
-    let n = 2;  // Must be a power of 2
+    let n = 4;  // Must be a power of 2
     let (g, g_order) = find_cyclic_subgroup(modulus, n);
     let omega = mod_exp(g, g_order / n, modulus);
     let root = primitive_root(23, 2);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod test;
 
-use ntt::{omega, ntt, intt , polymul, polymul_ntt};
+use reikna::totient::totient;
+use ntt::{omega, ntt, intt , polymul, polymul_ntt, find_cyclic_subgroup, primitive_root};
 
 fn main() {
     let p: i64 = 17; // Prime modulus
@@ -44,4 +45,13 @@ fn main() {
     println!("Resultant Polynomial (c): {:?}", c);
     println!("Standard polynomial mult. result: {:?}", c_std);
     println!("Polynomial multiplication method using NTT: {:?}", c_fast);
+
+    let modulus = 45; // Example modulus
+    let n = 4;  // Must be a power of 2
+    let (g, g_order) = find_cyclic_subgroup(modulus, n);
+    let root = primitive_root(23, 2);
+    println!("Primitive root: {}", root);
+    println!("(g, order) = {}, {}", g, g_order);
+    println!("g^g_order: {}", g.pow(g_order as u32) % modulus);
+    println!("Totient of {}: {}", modulus, totient(modulus as u64));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod test;
 
 use reikna::totient::totient;
-use ntt::{ntt, intt , polymul, polymul_ntt, mod_exp, mod_inv, verify_root_of_unity, divisors_with_given_lcm};
+use ntt::{ntt, intt , polymul, polymul_ntt, mod_exp, mod_inv, verify_root_of_unity};
 
 fn main() {
     let p: i64 = 17; // Prime modulus
@@ -76,11 +76,5 @@ fn main() {
     println!("Standard polynomial mult. result: {:?}", c_std);
     println!("Resultant Polynomial (c): {:?}", c);
     println!("Polynomial multiplication method using NTT: {:?}", c_fast);
-
-    //check that we can take a list of numbers and compute divisors such that their lcm = a number
-    let n = 8;
-    let phis = vec![8, 2]; // Example phi values
-    let divisors = divisors_with_given_lcm(&phis, n);
-    println!("{:?}", divisors); // Output a set of divisors whose LCM is n
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod test;
 
 use reikna::totient::totient;
-use ntt::{omega, ntt, intt , polymul, polymul_ntt, cyclic_subgroup_gen, mod_exp};
+use ntt::{omega, ntt, intt , polymul, polymul_ntt, cyclic_subgroup_gen, mod_exp, mod_inv};
 
 fn main() {
     let p: i64 = 17; // Prime modulus
@@ -45,10 +45,11 @@ fn main() {
     println!("Standard polynomial mult. result: {:?}", c_std);
     println!("Polynomial multiplication method using NTT: {:?}", c_fast);
 
-    let modulus = 45; // Example modulus
-    let n = 4;  // Must be a power of 2
+    let modulus = 51; // Example modulus
+    let n = 8;  // Must be a power of 2
     let omega = cyclic_subgroup_gen(modulus, n);
     println!("Totient of {}: {}", modulus, totient(modulus as u64));
     println!("omega: {}", omega);
     println!("omega^n: {}", mod_exp(omega, n, modulus));
+    println!("n^-1 = {}", mod_inv(n as i64, modulus));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,11 @@
 mod test;
 
-use reikna::totient::totient;
-use ntt::{ntt, intt , polymul, polymul_ntt, mod_exp, mod_inv, verify_root_of_unity};
+use ntt::{ntt, intt , polymul, polymul_ntt, verify_root_of_unity};
 
 fn main() {
-    let p: i64 = 17; // Prime modulus
+    let modulus: i64 = 17; // modulus, n must divide phi(p^k) for each prime factor p
     let n: usize = 8;  // Length of the NTT (must be a power of 2)
-    let omega = ntt::omega(p, n); // n-th root of unity: root^((p - 1) / n) % p
+    let omega = ntt::omega(modulus, n); // n-th root of unity
 
     // Input polynomials (padded to length `n`)
     let mut a = vec![1, 2, 3, 4];
@@ -15,27 +14,27 @@ fn main() {
     b.resize(n, 0);
 
     // Perform the forward NTT
-    let a_ntt = ntt(&a, omega, n, p);
-    let b_ntt = ntt(&b, omega, n, p);
+    let a_ntt = ntt(&a, omega, n, modulus);
+    let b_ntt = ntt(&b, omega, n, modulus);
 
     // Perform the inverse NTT on the transformed A for verification
-    let a_ntt_intt = intt(&a_ntt, omega, n, p);
+    let a_ntt_intt = intt(&a_ntt, omega, n, modulus);
 
     // Pointwise multiplication in the NTT domain
     let c_ntt: Vec<i64> = a_ntt
         .iter()
         .zip(b_ntt.iter())
-        .map(|(x, y)| (x * y) % p)
+        .map(|(x, y)| (x * y) % modulus)
         .collect();
 
     // Inverse NTT to get the polynomial product
-    let c = intt(&c_ntt, omega, n, p);
+    let c = intt(&c_ntt, omega, n, modulus);
 
-    let c_std = polymul(&a, &b, n as i64, p);
-    let c_fast = polymul_ntt(&a, &b, n, p, omega);
+    let c_std = polymul(&a, &b, n as i64, modulus);
+    let c_fast = polymul_ntt(&a, &b, n, modulus, omega);
 
     // Output the results
-    println!("verify omega = {}", verify_root_of_unity(omega, n as i64, p));
+    println!("verify omega = {}", verify_root_of_unity(omega, n as i64, modulus));
     println!("Polynomial A: {:?}", a);
     println!("Polynomial B: {:?}", b);
     println!("Transformed A: {:?}", a_ntt);
@@ -44,37 +43,6 @@ fn main() {
     println!("Pointwise Product in NTT Domain: {:?}", c_ntt);
     println!("Resultant Polynomial (c): {:?}", c);
     println!("Standard polynomial mult. result: {:?}", c_std);
-    println!("Polynomial multiplication method using NTT: {:?}", c_fast);
-
-    //test the composite modulus case
-    let modulus = 697; // Example modulus
-    let n = 8;  // Must be a power of 2
-    let omega = ntt::omega(modulus, n); // n-th root of unity
-    println!("Totient of {}: {}", modulus, totient(modulus as u64));
-    println!("omega: {}", omega);
-    println!("verify omega = {}", verify_root_of_unity(omega, n as i64, modulus));
-    (0..=n).for_each(|i| println!("omega^{}: {}", i, mod_exp(omega, i as i64, modulus)));
-    println!("n^-1 = {}", mod_inv(n as i64, modulus));
-    let a_ntt = ntt(&a, omega, n, modulus);
-    let b_ntt = ntt(&b, omega, n, modulus);
-    let a_ntt_intt = intt(&a_ntt, omega, n, modulus);
-    let b_ntt_intt = intt(&b_ntt, omega, n, modulus);
-    let c_ntt: Vec<i64> = a_ntt
-        .iter()
-        .zip(b_ntt.iter())
-        .map(|(x, y)| (x * y) % modulus)
-        .collect();
-    let c = intt(&c_ntt, omega, n, modulus);
-    let c_std = polymul(&a, &b, n as i64, modulus);
-    let c_fast = polymul_ntt(&a, &b, n, modulus, omega);
-    println!("A: {:?}", a);
-    println!("Transformed A: {:?}", a_ntt);
-    println!("Transformed B: {:?}", b_ntt);
-    println!("Recovered A: {:?}", a_ntt_intt);
-    println!("Recovered B: {:?}", b_ntt_intt);
-    println!("Pointwise Product in NTT Domain: {:?}", c_ntt);
-    println!("Standard polynomial mult. result: {:?}", c_std);
-    println!("Resultant Polynomial (c): {:?}", c);
     println!("Polynomial multiplication method using NTT: {:?}", c_fast);
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
     println!("Polynomial multiplication method using NTT: {:?}", c_fast);
 
     //test the composite modulus case
-    let modulus = 85; // Example modulus
+    let modulus = 697; // Example modulus
     let n = 8;  // Must be a power of 2
     let omega = ntt::omega(modulus, n); // n-th root of unity
     println!("Totient of {}: {}", modulus, totient(modulus as u64));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod test;
 
 use reikna::totient::totient;
-use ntt::{ntt, intt , polymul, polymul_ntt, mod_exp, mod_inv};
+use ntt::{ntt, intt , polymul, polymul_ntt, mod_exp, mod_inv, verify_root_of_unity};
 
 fn main() {
     let p: i64 = 17; // Prime modulus
@@ -51,6 +51,7 @@ fn main() {
     let omega = ntt::omega(modulus, n); // n-th root of unity
     println!("Totient of {}: {}", modulus, totient(modulus as u64));
     println!("omega: {}", omega);
+    println!("verify omega = {}", verify_root_of_unity(omega, n as i64, modulus));
     (0..=n).for_each(|i| println!("omega^{}: {}", i, mod_exp(omega, i as i64, modulus)));
     println!("n^-1 = {}", mod_inv(n as i64, modulus));
     let a_ntt = ntt(&a, omega, n, modulus);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod test;
 
 use reikna::totient::totient;
-use ntt::{omega, ntt, intt , polymul, polymul_ntt, find_cyclic_subgroup, primitive_root, mod_exp};
+use ntt::{omega, ntt, intt , polymul, polymul_ntt, find_cyclic_subgroup, primitive_root, mod_exp, crt};
 
 fn main() {
     let p: i64 = 17; // Prime modulus
@@ -56,4 +56,9 @@ fn main() {
     println!("(g, order) = {}, {}", g, g_order);
     println!("omega: {}", omega);
     println!("omega^n: {}", mod_exp(omega, n, modulus));
+
+    let x1 = crt(2, 3, 3, 5);
+    println!("Expected: 8, Computed: {}", x1);
+    let x3 = crt(4, 7, 5, 11);
+    println!("Expected: 60, Computed: {}", x3);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
     println!("Polynomial multiplication method using NTT: {:?}", c_fast);
 
     //test the composite modulus case
-    let modulus = 51; // Example modulus
+    let modulus = 85; // Example modulus
     let n = 8;  // Must be a power of 2
     let omega = ntt::omega(modulus, n); // n-th root of unity
     println!("Totient of {}: {}", modulus, totient(modulus as u64));
@@ -78,8 +78,8 @@ fn main() {
     println!("Polynomial multiplication method using NTT: {:?}", c_fast);
 
     //check that we can take a list of numbers and compute divisors such that their lcm = a number
-    let n = 12;
-    let phis = vec![4, 6, 6]; // Example phi values
+    let n = 8;
+    let phis = vec![8, 2]; // Example phi values
     let divisors = divisors_with_given_lcm(&phis, n);
     println!("{:?}", divisors); // Output a set of divisors whose LCM is n
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod test;
 
 use reikna::totient::totient;
-use ntt::{omega, ntt, intt , polymul, polymul_ntt, find_cyclic_subgroup, primitive_root};
+use ntt::{omega, ntt, intt , polymul, polymul_ntt, find_cyclic_subgroup, primitive_root, mod_exp};
 
 fn main() {
     let p: i64 = 17; // Prime modulus
@@ -47,11 +47,13 @@ fn main() {
     println!("Polynomial multiplication method using NTT: {:?}", c_fast);
 
     let modulus = 45; // Example modulus
-    let n = 4;  // Must be a power of 2
+    let n = 2;  // Must be a power of 2
     let (g, g_order) = find_cyclic_subgroup(modulus, n);
+    let omega = mod_exp(g, g_order / n, modulus);
     let root = primitive_root(23, 2);
+    println!("Totient of {}: {}", modulus, totient(modulus as u64));
     println!("Primitive root: {}", root);
     println!("(g, order) = {}, {}", g, g_order);
-    println!("g^g_order: {}", g.pow(g_order as u32) % modulus);
-    println!("Totient of {}: {}", modulus, totient(modulus as u64));
+    println!("omega: {}", omega);
+    println!("omega^n: {}", mod_exp(omega, n, modulus));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,11 +45,34 @@ fn main() {
     println!("Standard polynomial mult. result: {:?}", c_std);
     println!("Polynomial multiplication method using NTT: {:?}", c_fast);
 
+    //test the composite modulus case
     let modulus = 51; // Example modulus
     let n = 8;  // Must be a power of 2
     let omega = ntt::omega(modulus, n); // n-th root of unity
     println!("Totient of {}: {}", modulus, totient(modulus as u64));
     println!("omega: {}", omega);
-    println!("omega^n: {}", mod_exp(omega, n as i64, modulus));
+    (0..=n).for_each(|i| println!("omega^{}: {}", i, mod_exp(omega, i as i64, modulus)));
     println!("n^-1 = {}", mod_inv(n as i64, modulus));
+    let a_ntt = ntt(&a, omega, n, modulus);
+    let b_ntt = ntt(&b, omega, n, modulus);
+    let a_ntt_intt = intt(&a_ntt, omega, n, modulus);
+    let b_ntt_intt = intt(&b_ntt, omega, n, modulus);
+    let c_ntt: Vec<i64> = a_ntt
+        .iter()
+        .zip(b_ntt.iter())
+        .map(|(x, y)| (x * y) % modulus)
+        .collect();
+    let c = intt(&c_ntt, omega, n, modulus);
+    let c_std = polymul(&a, &b, n as i64, modulus);
+    let c_fast = polymul_ntt(&a, &b, n, modulus, omega);
+    println!("A: {:?}", a);
+    println!("Transformed A: {:?}", a_ntt);
+    println!("Transformed B: {:?}", b_ntt);
+    println!("Recovered A: {:?}", a_ntt_intt);
+    println!("Recovered B: {:?}", b_ntt_intt);
+    println!("Pointwise Product in NTT Domain: {:?}", c_ntt);
+    println!("Standard polynomial mult. result: {:?}", c_std);
+    println!("Resultant Polynomial (c): {:?}", c);
+    println!("Polynomial multiplication method using NTT: {:?}", c_fast);
+
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod test;
 
 use reikna::totient::totient;
-use ntt::{ntt, intt , polymul, polymul_ntt, mod_exp, mod_inv, verify_root_of_unity};
+use ntt::{ntt, intt , polymul, polymul_ntt, mod_exp, mod_inv, verify_root_of_unity, divisors_with_given_lcm};
 
 fn main() {
     let p: i64 = 17; // Prime modulus
@@ -76,5 +76,11 @@ fn main() {
     println!("Standard polynomial mult. result: {:?}", c_std);
     println!("Resultant Polynomial (c): {:?}", c);
     println!("Polynomial multiplication method using NTT: {:?}", c_fast);
+
+    //check that we can take a list of numbers and compute divisors such that their lcm = a number
+    let n = 12;
+    let phis = vec![4, 6, 6]; // Example phi values
+    let divisors = divisors_with_given_lcm(&phis, n);
+    println!("{:?}", divisors); // Output a set of divisors whose LCM is n
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod test;
 
 use reikna::totient::totient;
-use ntt::{omega, ntt, intt , polymul, polymul_ntt, find_cyclic_subgroup, primitive_root, mod_exp, crt};
+use ntt::{omega, ntt, intt , polymul, polymul_ntt, find_cyclic_subgroup, mod_exp};
 
 fn main() {
     let p: i64 = 17; // Prime modulus
@@ -48,17 +48,8 @@ fn main() {
 
     let modulus = 45; // Example modulus
     let n = 4;  // Must be a power of 2
-    let (g, g_order) = find_cyclic_subgroup(modulus, n);
-    let omega = mod_exp(g, g_order / n, modulus);
-    let root = primitive_root(23, 2);
+    let omega = find_cyclic_subgroup(modulus, n);
     println!("Totient of {}: {}", modulus, totient(modulus as u64));
-    println!("Primitive root: {}", root);
-    println!("(g, order) = {}, {}", g, g_order);
     println!("omega: {}", omega);
     println!("omega^n: {}", mod_exp(omega, n, modulus));
-
-    let x1 = crt(2, 3, 3, 5);
-    println!("Expected: 8, Computed: {}", x1);
-    let x3 = crt(4, 7, 5, 11);
-    println!("Expected: 60, Computed: {}", x3);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 mod test;
 
 use reikna::totient::totient;
-use ntt::{omega, ntt, intt , polymul, polymul_ntt, cyclic_subgroup_gen, mod_exp, mod_inv};
+use ntt::{ntt, intt , polymul, polymul_ntt, mod_exp, mod_inv};
 
 fn main() {
     let p: i64 = 17; // Prime modulus
     let n: usize = 8;  // Length of the NTT (must be a power of 2)
-    let omega = omega(p, n); // n-th root of unity: root^((p - 1) / n) % p
+    let omega = ntt::omega(p, n); // n-th root of unity: root^((p - 1) / n) % p
 
     // Input polynomials (padded to length `n`)
     let mut a = vec![1, 2, 3, 4];
@@ -47,9 +47,9 @@ fn main() {
 
     let modulus = 51; // Example modulus
     let n = 8;  // Must be a power of 2
-    let omega = cyclic_subgroup_gen(modulus, n);
+    let omega = ntt::omega(modulus, n); // n-th root of unity
     println!("Totient of {}: {}", modulus, totient(modulus as u64));
     println!("omega: {}", omega);
-    println!("omega^n: {}", mod_exp(omega, n, modulus));
+    println!("omega^n: {}", mod_exp(omega, n as i64, modulus));
     println!("n^-1 = {}", mod_inv(n as i64, modulus));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,12 @@
 mod test;
 
 use reikna::totient::totient;
-use ntt::{omega, ntt, intt , polymul, polymul_ntt, find_cyclic_subgroup, mod_exp};
+use ntt::{omega, ntt, intt , polymul, polymul_ntt, cyclic_subgroup_gen, mod_exp};
 
 fn main() {
     let p: i64 = 17; // Prime modulus
-    let root: i64 = 3; // Primitive root of unity for the modulus
     let n: usize = 8;  // Length of the NTT (must be a power of 2)
-    let omega = omega(root, p, n); // n-th root of unity: root^((p - 1) / n) % p
+    let omega = omega(p, n); // n-th root of unity: root^((p - 1) / n) % p
 
     // Input polynomials (padded to length `n`)
     let mut a = vec![1, 2, 3, 4];
@@ -48,7 +47,7 @@ fn main() {
 
     let modulus = 45; // Example modulus
     let n = 4;  // Must be a power of 2
-    let omega = find_cyclic_subgroup(modulus, n);
+    let omega = cyclic_subgroup_gen(modulus, n);
     println!("Totient of {}: {}", modulus, totient(modulus as u64));
     println!("omega: {}", omega);
     println!("omega^n: {}", mod_exp(omega, n, modulus));

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use ntt::{omega, polymul, polymul_ntt};
+    use ntt::{omega, polymul, polymul_ntt,mod_exp};
 
     #[test]
     fn test_polymul_ntt() {
@@ -70,15 +70,14 @@ mod tests {
 
     #[test]
     fn test_polymul_ntt_non_prime_power_modulus() {
-        let modulus: i64 = 45; // modulus p^k
+        let modulus: i64 = 45; // modulus not of the form p^k
         let n: usize = 4;  // Length of the NTT (must be a power of 2)
         let omega = omega(modulus, n); // n-th root of unity
+        println!("omega^n: {}", mod_exp(omega,n as i64,modulus));
 
         // Input polynomials (padded to length `n`)
         let mut a = vec![1, 2, 3, 4];
         let mut b = vec![4, 5, 6, 7];
-        a.resize(n, 0);
-        b.resize(n, 0);
 
         // Perform the standard polynomial multiplication
         let c_std = polymul(&a, &b, n as i64, modulus);

--- a/src/test.rs
+++ b/src/test.rs
@@ -70,14 +70,16 @@ mod tests {
 
     #[test]
     fn test_polymul_ntt_non_prime_power_modulus() {
-        let modulus: i64 = 45; // modulus not of the form p^k
-        let n: usize = 4;  // Length of the NTT (must be a power of 2)
+        let modulus: i64 = 51; // modulus not of the form p^k
+        let n: usize = 8;  // Length of the NTT (must be a power of 2)
         let omega = omega(modulus, n); // n-th root of unity
         println!("omega^n: {}", mod_exp(omega,n as i64,modulus));
 
         // Input polynomials (padded to length `n`)
         let mut a = vec![1, 2, 3, 4];
         let mut b = vec![4, 5, 6, 7];
+        a.resize(n, 0);
+        b.resize(n, 0);
 
         // Perform the standard polynomial multiplication
         let c_std = polymul(&a, &b, n as i64, modulus);

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use ntt::{omega, polymul, polymul_ntt,mod_exp};
+    use ntt::{omega, polymul, polymul_ntt};
 
     #[test]
     fn test_polymul_ntt() {
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn test_polymul_ntt_non_prime_power_modulus() {
-        let modulus: i64 = 51; // modulus not of the form p^k
+        let modulus: i64 = 697; // modulus not of the form p^k
         let n: usize = 8;  // Length of the NTT (must be a power of 2)
         let omega = omega(modulus, n); // n-th root of unity
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -70,24 +70,22 @@ mod tests {
 
     #[test]
     fn test_polymul_ntt_non_prime_power_modulus() {
-        let modulus: i64 = 697; // modulus not of the form p^k
+        let moduli = [17*41, 17*73, 17*41*73]; // Different moduli to test
         let n: usize = 8;  // Length of the NTT (must be a power of 2)
-        let omega = omega(modulus, n); // n-th root of unity
-
-        // Input polynomials (padded to length `n`)
-        let mut a = vec![1, 2, 3, 4];
-        let mut b = vec![4, 5, 6, 7];
-        a.resize(n, 0);
-        b.resize(n, 0);
-
-        // Perform the standard polynomial multiplication
-        let c_std = polymul(&a, &b, n as i64, modulus);
-        
-        // Perform the NTT-based polynomial multiplication
-        let c_fast = polymul_ntt(&a, &b, n, modulus, omega);
-
-        // Ensure both methods produce the same result
-        assert_eq!(c_std, c_fast, "The results of polymul and polymul_ntt do not match");
+    
+        for &modulus in &moduli {
+            let omega = omega(modulus, n);
+            
+            let mut a = vec![1, 2, 3, 4];
+            let mut b = vec![4, 5, 6, 7];
+            a.resize(n, 0);
+            b.resize(n, 0);
+    
+            let c_std = polymul(&a, &b, n as i64, modulus);
+            let c_fast = polymul_ntt(&a, &b, n, modulus, omega);
+    
+            assert_eq!(c_std, c_fast, "Failed for modulus {}", modulus);
+        }
     }
     
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -73,7 +73,6 @@ mod tests {
         let modulus: i64 = 51; // modulus not of the form p^k
         let n: usize = 8;  // Length of the NTT (must be a power of 2)
         let omega = omega(modulus, n); // n-th root of unity
-        println!("omega^n: {}", mod_exp(omega,n as i64,modulus));
 
         // Input polynomials (padded to length `n`)
         let mut a = vec![1, 2, 3, 4];

--- a/src/test.rs
+++ b/src/test.rs
@@ -5,9 +5,8 @@ mod tests {
     #[test]
     fn test_polymul_ntt() {
         let p: i64 = 17; // Prime modulus
-        let root: i64 = 3; // Primitive root of unity
         let n: usize = 8;  // Length of the NTT (must be a power of 2)
-        let omega = omega(root, p, n); // n-th root of unity
+        let omega = omega(p, n); // n-th root of unity
 
         // Input polynomials (padded to length `n`)
         let mut a = vec![1, 2, 3, 4];
@@ -28,9 +27,8 @@ mod tests {
     #[test]
     fn test_polymul_ntt_square_modulus() {
         let modulus: i64 = 17*17; // Prime modulus
-        let root: i64 = 3; // Primitive root of unity
         let n: usize = 8;  // Length of the NTT (must be a power of 2)
-        let omega = omega(root, modulus, n); // n-th root of unity
+        let omega = omega(modulus, n); // n-th root of unity
 
         // Input polynomials (padded to length `n`)
         let mut a = vec![1, 2, 3, 4];
@@ -51,9 +49,30 @@ mod tests {
     #[test]
     fn test_polymul_ntt_prime_power_modulus() {
         let modulus: i64 = (17 as i64).pow(4); // modulus p^k
-        let root: i64 = 3; // Primitive root of unity
         let n: usize = 8;  // Length of the NTT (must be a power of 2)
-        let omega = omega(root, modulus, n); // n-th root of unity
+        let omega = omega(modulus, n); // n-th root of unity
+
+        // Input polynomials (padded to length `n`)
+        let mut a = vec![1, 2, 3, 4];
+        let mut b = vec![4, 5, 6, 7];
+        a.resize(n, 0);
+        b.resize(n, 0);
+
+        // Perform the standard polynomial multiplication
+        let c_std = polymul(&a, &b, n as i64, modulus);
+        
+        // Perform the NTT-based polynomial multiplication
+        let c_fast = polymul_ntt(&a, &b, n, modulus, omega);
+
+        // Ensure both methods produce the same result
+        assert_eq!(c_std, c_fast, "The results of polymul and polymul_ntt do not match");
+    }
+
+    #[test]
+    fn test_polymul_ntt_non_prime_power_modulus() {
+        let modulus: i64 = 45; // modulus p^k
+        let n: usize = 4;  // Length of the NTT (must be a power of 2)
+        let omega = omega(modulus, n); // n-th root of unity
 
         // Input polynomials (padded to length `n`)
         let mut a = vec![1, 2, 3, 4];


### PR DESCRIPTION
when N is odd and n is a power of 2, we can sometimes find a cyclic subgroup C of the multiplicative group (Z/NZ)* such that n | |C|. in this case, we are able to compute an n^th root of unity by finding a generator g of C, and computing omega = g^{|C|/n}. 

note such a subgroup is not guaranteed to exist. for example, when N=45, \phi(45) = 24. we might hope for subgroups of size 1, 2, 4, 8. however, (Z/45Z)* \cong (Z/9Z)* x (Z/5Z)* \cong Z/6Z x Z/4Z, which does not have a subgroup of order 8. 

by using the Chinese remainder theorem and finding generators of factors, we can compute such a cyclic subgroup.